### PR TITLE
Update gumbo_libxml.pc.in

### DIFF
--- a/gumbo_libxml.pc.in
+++ b/gumbo_libxml.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: Gumbo libxml bindings
 Description: A libxml2-compatible API for the Gumbo HTML parser.
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lgumbo_libxml
+Libs: -L${libdir} -lgumbo_xml
 Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
/usr/bin/ld cannot find -lgumbo_libxml. Because shared libraries produced are libgumbo_xml.so\* not libgumbo_libxml.so*
